### PR TITLE
fix: dont ignore zero-length list

### DIFF
--- a/_packages/api/test/api.test.ts
+++ b/_packages/api/test/api.test.ts
@@ -16,7 +16,7 @@ import {
     isCallExpression,
     isPropertyAccessExpression,
     isIdentifier,
-    isStringLiteral,
+    isArrowFunction,
 } from "@typescript/ast";
 import assert from "node:assert";
 import {
@@ -161,7 +161,8 @@ test("Function", () => {
     const currentFiles = {
         "/tsconfig.json": "{}",
         "/src/index.ts": `function foo() {
-            console.log("hello", "world")
+            console.log("hello", "world");
+            () => "1";
         }`,
     };
     
@@ -194,6 +195,13 @@ test("Function", () => {
     assert.ok(isStringLiteral(arg1));
     assert.equal(arg0.text, "hello");
     assert.equal(arg1.text, "world");
+
+    let arrow_expr = body.statements[1]!;
+    assert.ok(isExpressionStatement(arrow_expr));
+    let arrow = arrow_expr.expression;
+    assert.ok(isArrowFunction(arrow));
+    assert.ok(isStringLiteral(arrow.body));
+    assert.equal(arrow.body.text, "1");
 });
 
 test("Benchmarks", async () => {

--- a/internal/api/encoder/encoder.go
+++ b/internal/api/encoder/encoder.go
@@ -228,7 +228,7 @@ func EncodeSourceFile(sourceFile *ast.SourceFile, id string) ([]byte, error) {
 	visitor := &ast.NodeVisitor{
 		Hooks: ast.NodeVisitorHooks{
 			VisitNodes: func(nodeList *ast.NodeList, visitor *ast.NodeVisitor) *ast.NodeList {
-				if nodeList == nil || len(nodeList.Nodes) == 0 {
+				if nodeList == nil {
 					return nodeList
 				}
 
@@ -440,7 +440,7 @@ func getChildrenPropertyMask(node *ast.Node) uint8 {
 		return (boolToByte(n.DotDotDotToken != nil) << 0) | (boolToByte(n.PropertyName != nil) << 1) | (boolToByte(n.Name() != nil) << 2) | (boolToByte(n.Initializer != nil) << 3)
 	case ast.KindFunctionDeclaration:
 		n := node.AsFunctionDeclaration()
-		return (boolToByte(n.Modifiers() != nil) << 0) | (boolToByte(n.AsteriskToken != nil) << 1) | (boolToByte(n.Name() != nil) << 2) | (boolToByte(n.TypeParameters != nil) << 3) | (boolToByte(n.Parameters != nil && len(n.Parameters.Nodes) > 0) << 4) | (boolToByte(n.Type != nil) << 5) | (boolToByte(n.Body != nil) << 6)
+		return (boolToByte(n.Modifiers() != nil) << 0) | (boolToByte(n.AsteriskToken != nil) << 1) | (boolToByte(n.Name() != nil) << 2) | (boolToByte(n.TypeParameters != nil) << 3) | (boolToByte(n.Parameters != nil) << 4) | (boolToByte(n.Type != nil) << 5) | (boolToByte(n.Body != nil) << 6)
 	case ast.KindInterfaceDeclaration:
 		n := node.AsInterfaceDeclaration()
 		return (boolToByte(n.Modifiers() != nil) << 0) | (boolToByte(n.Name() != nil) << 1) | (boolToByte(n.TypeParameters != nil) << 2) | (boolToByte(n.HeritageClauses != nil) << 3) | (boolToByte(n.Members != nil) << 4)


### PR DESCRIPTION
This fixes [here issue 1](https://github.com/microsoft/typescript-go/issues/2021) in a different way, because tsgo seems to intentionally distinguish between optional and non-optional fields.